### PR TITLE
⬆️ AGP 7, compile/target 33

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,9 +17,6 @@ android {
         }
     }
 
-    lintOptions {
-        abortOnError false
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -27,6 +24,9 @@ android {
     }
 
     ndkVersion "24.0.8215888"
+    lint {
+        abortOnError false
+    }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
+    namespace 'com.github.druk.dnssdsamples'
     compileSdkVersion 31
 
     defaultConfig {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 
 android {
     namespace 'com.github.druk.dnssdsamples'
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.github.druk.rxdnssd"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }
@@ -17,7 +17,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,9 +32,9 @@ android {
 dependencies {
     implementation project(':rx2dnssd')
 
-    implementation 'androidx.appcompat:appcompat:1.4.0'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.2'
+    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     testImplementation 'junit:junit:4.13.2'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.github.druk.dnssdsamples">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
             android:icon="@mipmap/ic_launcher"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.3.0'
         classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,8 @@ ext.preDexLibs = !project.hasProperty('disablePreDex')
 
 subprojects {
     project.plugins.whenPluginAdded { plugin ->
-        if ('com.android.build.gradle.AppPlugin'.equals(plugin.class.name) || 'com.android.build.gradle.LibraryPlugin'.equals(plugin.class.name)) {
+        if ('com.android.build.gradle.AppPlugin' == plugin.class.name ||
+            'com.android.build.gradle.LibraryPlugin' == plugin.class.name) {
             // enable or disable pre-dexing
             project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
         }
@@ -39,7 +40,6 @@ task clean(type: Delete) {
 
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
 apply from: "${rootDir}/publish-root.gradle"
-
 
 wrapper {
     // Change this version and run `./gradlew wrapper` in order to update the gradle wrapper.

--- a/dnssd/build.gradle
+++ b/dnssd/build.gradle
@@ -6,11 +6,11 @@ repositories {
 
 android {
     namespace 'com.github.druk.dnssd'
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 33
     }
 
     buildTypes {

--- a/dnssd/build.gradle
+++ b/dnssd/build.gradle
@@ -5,6 +5,7 @@ repositories {
 }
 
 android {
+    namespace 'com.github.druk.dnssd'
     compileSdkVersion 30
 
     defaultConfig {

--- a/dnssd/build.gradle
+++ b/dnssd/build.gradle
@@ -41,7 +41,7 @@ android {
 dependencies {
     testImplementation 'junit:junit:4.13.2'
     // Last version that support Power Mock: https://github.com/powermock/powermock/wiki/Mockito#supported-versions
-    testImplementation 'org.mockito:mockito-core:3.6.0'
+    testImplementation 'org.mockito:mockito-core:4.8.0'
     testImplementation ('org.powermock:powermock-api-mockito2:2.0.9') {
         exclude module: 'hamcrest-core'
         exclude module: 'objenesis'

--- a/dnssd/src/main/AndroidManifest.xml
+++ b/dnssd/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.druk.dnssd">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/rx2dnssd/build.gradle
+++ b/rx2dnssd/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'com.github.druk.rx2dnssd'
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 33
     }
 
     buildTypes {

--- a/rx2dnssd/build.gradle
+++ b/rx2dnssd/build.gradle
@@ -33,11 +33,11 @@ dependencies {
     // Transitively export that dependencies to other modules
     api 'io.reactivex.rxjava2:rxandroid:2.1.1'
     api 'io.reactivex.rxjava2:rxjava:2.2.21'
-    api 'androidx.annotation:annotation:1.3.0'
+    api 'androidx.annotation:annotation:1.5.0'
 
     testImplementation 'junit:junit:4.13.2'
     // Last version that support Power Mock: https://github.com/powermock/powermock/wiki/Mockito#supported-versions
-    testImplementation 'org.mockito:mockito-core:3.6.0'
+    testImplementation 'org.mockito:mockito-core:4.8.0'
     testImplementation ('org.powermock:powermock-api-mockito2:2.0.9') {
         exclude module: 'hamcrest-core'
         exclude module: 'objenesis'

--- a/rx2dnssd/build.gradle
+++ b/rx2dnssd/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.github.druk.rx2dnssd'
     compileSdkVersion 30
 
     defaultConfig {

--- a/rx2dnssd/src/main/AndroidManifest.xml
+++ b/rx2dnssd/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.druk.rx2dnssd">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/rxdnssd/build.gradle
+++ b/rxdnssd/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 
 android {
     namespace 'com.github.druk.rxdnssd'
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 33
     }
 
     buildTypes {

--- a/rxdnssd/build.gradle
+++ b/rxdnssd/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.github.druk.rxdnssd'
     compileSdkVersion 30
 
     defaultConfig {

--- a/rxdnssd/build.gradle
+++ b/rxdnssd/build.gradle
@@ -33,11 +33,11 @@ dependencies {
     // Transitively export that dependencies to other modules
     api 'io.reactivex:rxandroid:1.2.1'
     api 'io.reactivex:rxjava:1.3.8'
-    api 'androidx.annotation:annotation:1.3.0'
+    api 'androidx.annotation:annotation:1.5.0'
 
     testImplementation 'junit:junit:4.13.2'
     // Last version that support Power Mock: https://github.com/powermock/powermock/wiki/Mockito#supported-versions
-    testImplementation 'org.mockito:mockito-core:3.6.0'
+    testImplementation 'org.mockito:mockito-core:4.8.0'
     testImplementation ('org.powermock:powermock-api-mockito2:2.0.9') {
         exclude module: 'hamcrest-core'
         exclude module: 'objenesis'

--- a/rxdnssd/src/main/AndroidManifest.xml
+++ b/rxdnssd/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.github.druk.rxdnssd">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
Also updated dependencies:

- annotation (1.5.0)
- appcompat (1.4.2)
- constraintlayout (2.1.4)
- material (1.6.1)
- mockito-core (4.8.0)

Intentionally didn't update to latest appcompat as that requires apps to have `compileSdk` = 33. This set is compatible with `compileSdk` >= 31.